### PR TITLE
Fix/world gen performance

### DIFF
--- a/Assets/WorldGen/TerrainManager.cs
+++ b/Assets/WorldGen/TerrainManager.cs
@@ -37,12 +37,31 @@ public class TerrainManager : MonoBehaviour
         int xStart, xEnd, zStart, zEnd;
         xStart =  playerPosChunks.x - generateRadius; 
         xEnd = playerPosChunks.x + generateRadius;
+
+        // Generate a fixed amount of frames per UPDATE call
+        // If this were FixedUpdate, we'd run into an issue where we could only hit a certain render distance
+        // However, because this is Update, update should get called more frequently on a more powerful computer and thus
+        // world generation can scale to higher chunk distances
+        const byte CHUNKS_TO_GENERATE_PER_FRAME = 3;
+        int chunksGeneratedThisFrame = 0; 
+
         for (int xIndex = xStart; xIndex < xEnd; xIndex++)
         {
             zStart = playerPosChunks.y - generateRadius; 
             zEnd = playerPosChunks.y + generateRadius;
+
+            if (chunksGeneratedThisFrame > CHUNKS_TO_GENERATE_PER_FRAME)
+            {
+                return;
+            }
+
             for (int zIndex = zStart; zIndex < zEnd; zIndex++)
             {
+                if (chunksGeneratedThisFrame > CHUNKS_TO_GENERATE_PER_FRAME)
+                {
+                    return;
+                }
+
                 // Chunk pos (in chunks)
                 Vector2 pos = new Vector2(xIndex, zIndex);
 
@@ -65,7 +84,8 @@ public class TerrainManager : MonoBehaviour
                     // Syntax: Instantiate(<prefab>, <parent transform>, <rotation>)
                     GameObject tile = Instantiate(tilePrefab, chunkPos, Quaternion.identity) as GameObject;
                     chunks[pos] = tile;
-                }                
+                    chunksGeneratedThisFrame++;
+                }
             }
         }
     }


### PR DESCRIPTION
Implements the following:
- **Limits number of chunks generated per frame.** This means the game will no longer stutter as it generates every chunk in range right when the player steps into a new chunk. Could (and should) find a more elegant solution for this involving multithreading, coroutines, and/or scaling the "chunks per frame" constant based on an FPS goal or machine specs.
- **Generates chunks outwards from the player rather than min x/z to max x/z**. We will eventually do a "fog" that has radius as far outwards as we've generated so far, but for that, we need it to be centered around the player.
- **Implements some randomness to vertex locations**. The world no longer looks like it's on a grid-based system (at least, on a subchunk basis) and actually looks really cool. I don't change vertex positions for vertices that are on the edge of their chunk, as those need to be continuous with the neighboring chunks - note that this will cause slightly noticeable artifacts along chunk borders, and it's something that needs fixed in the future. 