### PR TITLE
Extend terrain height raycast to return normal vector

### DIFF
--- a/Assets/WorldGen/TerrainFunctions.cs
+++ b/Assets/WorldGen/TerrainFunctions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Assets.WorldGen
@@ -6,8 +7,31 @@ namespace Assets.WorldGen
     /* Contains high-level, useful functions for interfacing with the terrain system. */
     public class Terrain
     {
-        // Performs a Raycast to get terrain height at a given (x, z) represented as a Vector2.
-        static float GetHeightAtPoint(Vector2 point)
+        struct TerrainPointData
+        {
+            // Stores the y-coordinate that the raycast hit the terrain layer
+            public float height;
+
+            // Stores the normal vector at the hit point; lets us do things like:
+            // - Tilt trees according to terrain
+            // - Don't generate trees and other flora on very steep hills
+            public Vector3 normal; 
+
+            // Stores whether the raycast actually collided with the terrain layer or not
+            public bool isHit;
+
+            public TerrainPointData(float height, Vector3 normal, bool isHit)
+            {
+                this.height = height;
+                this.normal = normal;
+                this.isHit = isHit;
+            }
+        }
+
+        // Performs a Raycast to get terrain height and normal vector at a given (x, z) point. 
+        // Returns a TerrainPointData object. The `isHit` property stores whether the raycast actually
+        // collided with the terrain layer; `height` and `normal` are gibberish if `isHit` is false.
+        static TerrainPointData GetTerrainPointData(Vector2 point)
         {
             // Cast a ray from really high up to straight down, hitting the ground
             Ray ray = new Ray(new Vector3(point.x, Mathf.Infinity, point.y), Vector3.down);
@@ -16,11 +40,12 @@ namespace Assets.WorldGen
             RaycastHit hit;
             if (Physics.Raycast(ray, out hit, Mathf.Infinity, LayerMask.NameToLayer("Terrain")))
             {
-                return hit.point.y;
+                return new TerrainPointData(hit.point.y, hit.normal, true);
             }
 
-            // Should only get here if we call this function somewhere that doesn't currently have a chunk loaded
-            return -1;
+            // Should only get to this value if function is called on a chunk that has not been instantiated.
+            // isHit defaults to `false`. 
+            return new TerrainPointData();
         }
         // Use this for initialization
         void Start()


### PR DESCRIPTION
Function now returns a struct representing the height, normal vector, and bool representing whether it actually hit.