### PR TITLE
Better, more versatile noise interface

### DIFF
--- a/Assets/WorldGen/Chunk.prefab
+++ b/Assets/WorldGen/Chunk.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 6322903469593028111}
   - component: {fileID: 6322903469593028110}
   - component: {fileID: 6322903469593028099}
-  - component: {fileID: 6322903469593028098}
   m_Layer: 0
   m_Name: Chunk
   m_TagString: Untagged
@@ -136,17 +135,7 @@ MonoBehaviour:
     name: snow
     height: 0.7
     color: {r: 0.9339623, g: 0.8062033, b: 0.8062033, a: 1}
-  noise: {fileID: 6322903469593028098}
-  waves:
-  - seed: 1
-    frequency: 1
-    amplitude: 1
-  - seed: 2
-    frequency: 0.5
-    amplitude: 2
-  - seed: 3
-    frequency: 0.25
-    amplitude: 4
+  noise: {fileID: 0}
   meshRenderer: {fileID: 6322903469593028111}
   meshFilter: {fileID: 6322903469593028108}
   meshCollider: {fileID: 6322903469593028110}
@@ -204,15 +193,3 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &6322903469593028098
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6322903469593028105}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 15da3f6a02c99134c868b7b3961a79ce, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/WorldGen/ChunkGen.cs
+++ b/Assets/WorldGen/ChunkGen.cs
@@ -46,6 +46,8 @@ public class ChunkGen : MonoBehaviour
     [SerializeField]
     private MeshCollider meshCollider;
 
+    private Noise heightNoise; 
+
     // Holds the inner triangulation of this chunk in Triangle.NET's format
     private TriangleNet.Mesh mesh;
 
@@ -236,8 +238,10 @@ public class ChunkGen : MonoBehaviour
         gameObject.GetComponent<MeshCollider>().sharedMesh = actualMesh;
         
         List<Vector2> tempVertices = Vector3ToVector2(this.meshFilter.mesh.vertices);
-        float offsetX = transform.position.x, offsetZ = transform.position.z; 
-        List<float> noiseValues = this.noise.GenerateNoiseMap(tempVertices, this.mapScale, offsetX, offsetZ, waves);
+        float offsetX = transform.position.x, offsetZ = transform.position.z;
+
+        this.heightNoise = gameObject.AddComponent<Noise>();
+        List<float> noiseValues = this.heightNoise.GenerateNoiseMap(tempVertices, offsetX, offsetZ);
         UpdateVertexHeightsAndColors(this.meshFilter.mesh, noiseValues);
         gameObject.GetComponent<MeshCollider>().sharedMesh = gameObject.GetComponent<MeshFilter>().mesh;
     }

--- a/Assets/WorldGen/Noise.cs
+++ b/Assets/WorldGen/Noise.cs
@@ -2,8 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-// Modifying the default Perlin noise generation attributes to make our noise generation more realistic 
-[System.Serializable]
+// Noise is constructed by a combination of waves
 public class Wave
 {
     public float seed;
@@ -13,8 +12,62 @@ public class Wave
 
 public class Noise : MonoBehaviour
 {
-    // Given a List of Vector2 objects, returns a same-ordered list of corresponding noise values.
-    public List<float> GenerateNoiseMap(List<Vector2> localPoints, float scale, float offsetX, float offsetZ, Wave[] waves)
+    public Wave[] waves;
+    public float scale;
+
+    private const float DEFAULT_SCALE = 100;
+
+    // The implementer can either specify their own waves to feed into the constructor or use this function to get a random set of waves that will perform well
+    public static Wave[] GenWaves()
+    {
+        Wave[] waves = new Wave[3];
+        waves[0] = new Wave();
+        waves[1] = new Wave();
+        waves[2] = new Wave();
+
+        // Randomize Seeds
+        waves[0].seed = Random.Range(0, 10000);
+        waves[1].seed = Random.Range(0, 10000);
+        waves[2].seed = Random.Range(0, 10000);
+        
+        // Essentially simulating octaves, which are weaker, but more detailed layers added on top of each other
+        waves[0].amplitude = 4;
+        waves[1].amplitude = 2;
+        waves[2].amplitude = 1;
+        waves[0].frequency = 1;
+        waves[1].frequency = 2;
+        waves[2].frequency = 4;
+
+        return waves;
+    }
+
+    private void Awake()
+    {
+        this.waves = GenWaves();
+        this.scale = DEFAULT_SCALE; // Arbitrary number modifiable by the callee after constructor
+    }
+
+    // Main interface function for noise, allowing you to get the value of this Noise at a given (*world space*) x,z coord
+    public float GetNoiseAtPoint(float x, float z)
+    {
+        float sampleX = x / scale;
+        float sampleZ = z / scale;
+
+        float noise = 0f;
+        float normalization = 0f;
+        foreach (Wave wave in waves)
+        {
+            noise += wave.amplitude * Mathf.PerlinNoise(sampleX * wave.frequency + wave.seed, sampleZ * wave.frequency + wave.seed);
+            normalization += wave.amplitude;
+        }
+
+        // Normalize to [0, 1] by saving the amplification we did 
+        noise /= normalization;
+        return noise;
+    }
+
+    // ADVISED NOT TO USE THIS - An old version just kept for usage with heightmap generation, and thus doesn't really follow good design patterns
+    public List<float> GenerateNoiseMap(List<Vector2> localPoints, float offsetX, float offsetZ)
     {
         List<float> noises = new List<float>();
         foreach (Vector2 point in localPoints)
@@ -36,7 +89,7 @@ public class Noise : MonoBehaviour
             noise /= normalization;
             noises.Add(noise);
         }
-                
+
         return noises;
     }
 }

--- a/Assets/WorldGen/Scenes/worldGen.unity
+++ b/Assets/WorldGen/Scenes/worldGen.unity
@@ -606,7 +606,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2731847666348560380, guid: 58d784a71e1628e42880c15717248e3e, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2731847666348560380, guid: 58d784a71e1628e42880c15717248e3e, type: 3}
       propertyPath: moveSpeed
@@ -614,7 +614,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2731847666348560382, guid: 58d784a71e1628e42880c15717248e3e, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2731847666348560383, guid: 58d784a71e1628e42880c15717248e3e, type: 3}
       propertyPath: m_RootOrder
@@ -674,7 +674,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2731847667364621170, guid: 58d784a71e1628e42880c15717248e3e, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2731847667364621174, guid: 58d784a71e1628e42880c15717248e3e, type: 3}
       propertyPath: orthographic


### PR DESCRIPTION
Implements the Noise class in a way that's much more versatile and easy to link in with. The class works by constructing a `Noise` object representing a given Perlin map. **Default usage returns a random Perlin map, and should be enough for 90% of scenarios.** For example, we use one for the heightmap, and will likely use one for things like moisture and biome blending - really anything where a continuous randomization function would be useful. 

Minimal Demo:
```cs
// Class member variables
private Noise noise;

// In Start()
this.noise = gameObject.CreateComponent<Noise>(); // Constructs a Noise object, which defaults to random seeding and default density

// When actually getting Perlin noise values
float noiseValue = noise.GetNoiseAtPoint(<x>, <z>); 
```

Additional Tweaks:
- **To adjust the density of the Perlin map**: Do `noise.scale = <your value>` after constructing the Noise object. A high scale number (i.e. 200+ when talking about a heightmap) results in less change in the Perlin map per x,z shift (i.e. a flatter heightmap), and conversely a low scale number (i.e. below 50 when talking about a heightmap) results in more change in the Perlin map per x,z shift (i.e. a more jagged heightmap). 