### PR TITLE
Noise color randomization

### DIFF
--- a/Assets/FlatKit/[Render Pipeline] Built-In.unitypackage.meta
+++ b/Assets/FlatKit/[Render Pipeline] Built-In.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f4227764308e84f89a765fbf315e2945
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FlatKit/[Render Pipeline] Universal (URP).unitypackage.meta
+++ b/Assets/FlatKit/[Render Pipeline] Universal (URP).unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41e59f562b69648719f2424c438758f3
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorldGen/Chunk.prefab
+++ b/Assets/WorldGen/Chunk.prefab
@@ -122,7 +122,7 @@ MonoBehaviour:
   - randomizationFactor: 0.5
     name: lowlands
     height: 0.48
-    color: {r: 0.08167672, g: 1, b: 0, a: 1}
+    color: {r: 0.12223364, g: 0.5566038, b: 0.08086506, a: 1}
   - randomizationFactor: 0.15
     name: highlands
     height: 0.57

--- a/Assets/WorldGen/Chunk.prefab
+++ b/Assets/WorldGen/Chunk.prefab
@@ -111,37 +111,35 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tilePrefab: {fileID: 6322903469593028105}
   terrainTypes:
-  - randomizationFactor: 0.05
-    name: water
-    height: 0
+  - start: 0
+    end: 0
     color: {r: 0, g: 0.12516737, b: 1, a: 1}
-  - randomizationFactor: 0.05
-    name: beach
-    height: 0.3
+    randomizationFactor: 0.05
+  - start: 0
+    end: 0.25
     color: {r: 0.5800872, g: 0.5849056, b: 0.41660732, a: 1}
-  - randomizationFactor: 0.5
-    name: lowlands
-    height: 0.48
+    randomizationFactor: 0.05
+  - start: 0.25
+    end: 0.4
     color: {r: 0.12223364, g: 0.5566038, b: 0.08086506, a: 1}
-  - randomizationFactor: 0.15
-    name: highlands
-    height: 0.57
-    color: {r: 0.08725024, g: 0.20754719, b: 0.047970816, a: 1}
-  - randomizationFactor: 0.075
-    name: mountains
-    height: 0.65
+    randomizationFactor: 0.5
+  - start: 0.4
+    end: 0.47
+    color: {r: 0.12848811, g: 0.2924528, b: 0.07559627, a: 1}
+    randomizationFactor: 0.05
+  - start: 0.47
+    end: 0.54
     color: {r: 0.24528301, g: 0.15852223, b: 0.09140263, a: 1}
-  - randomizationFactor: 0.1
-    name: snow
-    height: 0.7
+    randomizationFactor: 0.075
+  - start: 0.54
+    end: 1
     color: {r: 0.9339623, g: 0.8062033, b: 0.8062033, a: 1}
-  noise: {fileID: 0}
+    randomizationFactor: 0.1
   meshRenderer: {fileID: 6322903469593028111}
   meshFilter: {fileID: 6322903469593028108}
   meshCollider: {fileID: 6322903469593028110}
-  mapScale: 30
   coords: {x: 0, y: 0}
-  heightMultiplier: 100
+  heightMultiplier: 120
   heightCurve:
     serializedVersion: 2
     m_Curve:

--- a/Assets/WorldGen/ChunkMaterial.mat
+++ b/Assets/WorldGen/ChunkMaterial.mat
@@ -10,7 +10,7 @@ Material:
   m_Name: ChunkMaterial
   m_Shader: {fileID: 4800000, guid: bee44b4a58655ee4cbff107302a3e131, type: 3}
   m_ShaderKeywords: DR_OUTLINE_ON DR_VERTEX_COLORS_ON _CELPRIMARYMODE_NONE _TEXTUREBLENDINGMODE_MULTIPLY
-    _UNITYSHADOWMODE_NONE
+    _UNITYSHADOWMODE_MULTIPLY
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -123,7 +123,7 @@ Material:
     - _TextureBlendingMode: 0
     - _TextureImpact: 1
     - _UVSec: 0
-    - _UnityShadowMode: 0
+    - _UnityShadowMode: 1
     - _UnityShadowOcclusion: 0
     - _UnityShadowPower: 0.7
     - _UnityShadowSharpness: 3

--- a/Assets/WorldGen/ChunkMaterial.mat
+++ b/Assets/WorldGen/ChunkMaterial.mat
@@ -10,7 +10,7 @@ Material:
   m_Name: ChunkMaterial
   m_Shader: {fileID: 4800000, guid: bee44b4a58655ee4cbff107302a3e131, type: 3}
   m_ShaderKeywords: DR_OUTLINE_ON DR_VERTEX_COLORS_ON _CELPRIMARYMODE_NONE _TEXTUREBLENDINGMODE_MULTIPLY
-    _UNITYSHADOWMODE_MULTIPLY _UNITYSHADOW_OCCLUSION
+    _UNITYSHADOWMODE_NONE
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -123,8 +123,8 @@ Material:
     - _TextureBlendingMode: 0
     - _TextureImpact: 1
     - _UVSec: 0
-    - _UnityShadowMode: 1
-    - _UnityShadowOcclusion: 1
+    - _UnityShadowMode: 0
+    - _UnityShadowOcclusion: 0
     - _UnityShadowPower: 0.7
     - _UnityShadowSharpness: 3
     - _VertexColorsEnabled: 1

--- a/Assets/WorldGen/Noise.cs
+++ b/Assets/WorldGen/Noise.cs
@@ -17,8 +17,9 @@ public class Noise : MonoBehaviour
 
     private const float DEFAULT_SCALE = 100;
 
-    // The implementer can either specify their own waves to feed into the constructor or use this function to get a random set of waves that will perform well
-    public static Wave[] GenWaves()
+    // Get a random set of waves that will perform well
+    // If the implementer wants a non-random set of waves, they can modify this.waves after constructing
+    private Wave[] GenWaves()
     {
         Wave[] waves = new Wave[3];
         waves[0] = new Wave();
@@ -41,7 +42,7 @@ public class Noise : MonoBehaviour
         return waves;
     }
 
-    private void Awake()
+    void Awake()
     {
         this.waves = GenWaves();
         this.scale = DEFAULT_SCALE; // Arbitrary number modifiable by the callee after constructor

--- a/Assets/WorldGen/Scenes/worldGen.unity
+++ b/Assets/WorldGen/Scenes/worldGen.unity
@@ -276,7 +276,7 @@ Light:
   m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
-    m_Type: 2
+    m_Type: 0
     m_Resolution: -1
     m_CustomResolution: -1
     m_Strength: 1
@@ -577,7 +577,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tilePrefab: {fileID: 6322903469593028105, guid: 2f020166ef04cae4bad76b88ada1ac75, type: 3}
   player: {fileID: 1782234108}
-  generateRadius: 6
+  generateRadius: 3
   TreeRockDropper: {fileID: 926933605}
 --- !u!4 &1240365349
 Transform:

--- a/Assets/WorldGen/Scenes/worldGen.unity
+++ b/Assets/WorldGen/Scenes/worldGen.unity
@@ -577,7 +577,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tilePrefab: {fileID: 6322903469593028105, guid: 2f020166ef04cae4bad76b88ada1ac75, type: 3}
   player: {fileID: 1782234108}
-  generateRadius: 3
+  generateRadius: 8
   TreeRockDropper: {fileID: 926933605}
 --- !u!4 &1240365349
 Transform:
@@ -840,7 +840,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1886648248}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 25, z: 0}
+  m_LocalPosition: {x: 0, y: 29, z: 0}
   m_LocalScale: {x: 200, y: 1, z: 200}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/WorldGen/TerrainManager.cs
+++ b/Assets/WorldGen/TerrainManager.cs
@@ -16,6 +16,10 @@ public class TerrainManager : MonoBehaviour
 
     public GameObject TreeRockDropper;
 
+    public static Noise heightNoise; // Used for heightmap values
+    public static Noise colorRandomizationNoise; // Used to randomize vertex colors a little bit
+    public static Noise heightFuzzingNoise; // Used to semi-randomly alter biome height cutoffs so it's less jarring when we get a shift
+
     // Holds references to chunks we've generated so that we don't regenerate them 
     static private Dictionary<Vector2Int, GameObject> chunks = new Dictionary<Vector2Int, GameObject>();
 
@@ -25,7 +29,14 @@ public class TerrainManager : MonoBehaviour
         Debug.Log("Start - TerrainManager");
         Physics.autoSyncTransforms = true;
         //player = GameObject.Find("WorldGenPlayer");
-       
+
+        // Initialize noise functions used by World Generation
+        heightNoise = gameObject.AddComponent<Noise>(); // Heightmap
+        colorRandomizationNoise = gameObject.AddComponent<Noise>(); // Used to tweak vertex colors a bit to give us a more tesselated look
+        colorRandomizationNoise.scale = 50;
+        heightFuzzingNoise = gameObject.AddComponent<Noise>(); // Used to make biome height boundaries a little more fuzzy to avoid the discrete layers look
+        heightFuzzingNoise.scale = 50;
+
         GenerateChunks();
 
     }

--- a/Assets/WorldGen/TerrainManager.cs
+++ b/Assets/WorldGen/TerrainManager.cs
@@ -32,6 +32,7 @@ public class TerrainManager : MonoBehaviour
 
         // Initialize noise functions used by World Generation
         heightNoise = gameObject.AddComponent<Noise>(); // Heightmap
+        heightNoise.scale = 130;
         colorRandomizationNoise = gameObject.AddComponent<Noise>(); // Used to tweak vertex colors a bit to give us a more tesselated look
         colorRandomizationNoise.scale = 50;
         heightFuzzingNoise = gameObject.AddComponent<Noise>(); // Used to make biome height boundaries a little more fuzzy to avoid the discrete layers look

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.17f1
-m_EditorVersionWithRevision: 2020.3.17f1 (a4537701e4ab)
+m_EditorVersion: 2020.3.21f1
+m_EditorVersionWithRevision: 2020.3.21f1 (a38c86f6690f)


### PR DESCRIPTION
Implements three separate things:
1. **Semi-random triangle recoloration.** Most coloration is done based off of a new Perlin map, which minimizes the splotchy effect of the old randomization, but a little bit of entirely random coloration is still in to help differentiate vertices right next to each other and at the same heightmap value. 
2. **Height Fuzzing.** Previously, biomes were very clearly differentiated by height, and we had very discrete "height lines" around the world. Height fuzzing varies this height value based on (yet another) Perlin map, adjusting this cutoff so that it's not consistent around the world.
3. **Height-based Biome Blending.** The minimum and maximum 15% of each biome's height range are blended via a gradient system into the biome that is right next to them. This helps further minimize the visibility and throw-off effect of the height lines. 

![image](https://user-images.githubusercontent.com/30580900/140993429-91a74984-bad3-4704-b7b0-99cd5accd535.png)
