### PR TITLE
Dont spawn on steep land

### DIFF
--- a/Assets/WorldGen/BiomeDefs.cs
+++ b/Assets/WorldGen/BiomeDefs.cs
@@ -137,7 +137,7 @@ namespace Assets.WorldGen
             List<PlantInfo> plantTypes = new List<PlantInfo>();
             plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .7f });
             plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .8f });
+            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .5f });
             plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .4f });
             plantTypes.Add(new PlantInfo() { name = "Grass3D", frequency = .7f });
             return plantTypes;
@@ -163,7 +163,7 @@ namespace Assets.WorldGen
             List<PlantInfo> plantTypes = new List<PlantInfo>();
             plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .3f });
             plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .2f });
+            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .1f });
             plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .3f });
             plantTypes.Add(new PlantInfo() { name = "PineTree", frequency = .7f });
             plantTypes.Add(new PlantInfo() { name = "Grass3D", frequency = 1 });
@@ -192,7 +192,7 @@ namespace Assets.WorldGen
             List<PlantInfo> plantTypes = new List<PlantInfo>();
             plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .2f });
             plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .3f });
+            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .1f });
             plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .3f });
             plantTypes.Add(new PlantInfo() { name = "PineTree", frequency = .8f });
             return plantTypes;
@@ -216,7 +216,7 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "Reeds", frequency = .4f });
+            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .4f });
             return plantTypes;
         }
     }

--- a/Assets/WorldGen/BiomeDefs.cs
+++ b/Assets/WorldGen/BiomeDefs.cs
@@ -24,8 +24,24 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "Reeds", frequency = .5f });
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Reeds",
+                frequency = .7f,
+                bunchChance = .8f,
+                minBunchSize = 2,
+                maxBunchSize = 5,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .2f,
+                bunchChance = .8f,
+                minBunchSize = 2,
+                maxBunchSize = 5,
+                bunchRadius = 2
+            });
             return plantTypes;
         }
     }
@@ -48,10 +64,26 @@ namespace Assets.WorldGen
         {
             // TODO: Idea: Moving Tumbleweeds
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .4f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "DeadBush",
+                frequency = .3f,
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .2f,
+                bunchChance = 1f,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
             // plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .2f });
-            plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .2f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeStump",
+                frequency = .2f
+            });
             return plantTypes;
         }
     }
@@ -73,16 +105,72 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "Bush", frequency = .6f });
-            plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .2f });
-            plantTypes.Add(new PlantInfo() { name = "FlowerBush", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "FlowersTwoSided", frequency = .6f });
-            plantTypes.Add(new PlantInfo() { name = "Grass3D", frequency = 1 });
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .2f });
-            plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "BirchTree", frequency = .7f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Bush",
+                frequency = .6f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = .5f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "DeadBush",
+                frequency = .2f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "FlowerBush",
+                frequency = .3f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 8,
+                bunchRadius = .5f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "FlowersTwoSided",
+                frequency = .6f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Grass3D",
+                frequency = 1,
+                bunchChance = 1,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .1f,
+                bunchChance = 1f,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeStump",
+                frequency = .3f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "BirchTree",
+                frequency = .7f
+            });
             // plantTypes.Add(new PlantInfo() { name = "BirchTreeLeafless", frequency = .7f });
-            plantTypes.Add(new PlantInfo() { name = "OakTree", frequency = .5f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "OakTree",
+                frequency = .5f
+            });
             return plantTypes;
         }
     }
@@ -104,16 +192,80 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "Bush", frequency = .6f });
-            plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .6f });
-            plantTypes.Add(new PlantInfo() { name = "FlowerBush", frequency = .6f });
-            plantTypes.Add(new PlantInfo() { name = "FlowersTwoSided", frequency = .7f });
-            plantTypes.Add(new PlantInfo() { name = "Grass3D", frequency = .9f });
-            plantTypes.Add(new PlantInfo() { name = "Mushrooms", frequency = .8f });
-            plantTypes.Add(new PlantInfo() { name = "Reeds", frequency = .4f });
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Bush",
+                frequency = .6f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "DeadBush",
+                frequency = .6f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "FlowerBush",
+                frequency = .6f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "FlowersTwoSided",
+                frequency = .7f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Grass3D",
+                frequency = 1,
+                bunchChance = 1,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Mushrooms",
+                frequency = .8f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Reeds",
+                frequency = .4f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .2f,
+                bunchChance = 1f,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
             // plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .2f });
-            plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .2f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeStump",
+                frequency = .2f
+            });
             return plantTypes;
         }
     }
@@ -135,11 +287,39 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .7f });
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .5f });
-            plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .4f });
-            plantTypes.Add(new PlantInfo() { name = "Grass3D", frequency = .7f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "DeadBush",
+                frequency = .7f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .1f,
+                bunchChance = .4f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 1
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeLeafless",
+                frequency = .5f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeStump",
+                frequency = .4f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Grass3D",
+                frequency = 1f,
+                bunchChance = 1,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
             return plantTypes;
         }
     }
@@ -161,14 +341,62 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .1f });
-            plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "PineTree", frequency = .7f });
-            plantTypes.Add(new PlantInfo() { name = "Grass3D", frequency = 1 });
-            plantTypes.Add(new PlantInfo() { name = "Bush", frequency = .6f });
-            plantTypes.Add(new PlantInfo() { name = "FlowerBush", frequency = .6f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "DeadBush",
+                frequency = .3f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .3f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeLeafless",
+                frequency = .1f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeStump",
+                frequency = .3f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "PineTree",
+                frequency = .7f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Grass3D",
+                frequency = 1,
+                bunchChance = 1,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Bush",
+                frequency = .6f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "FlowerBush",
+                frequency = .6f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
             return plantTypes;
         }
     }
@@ -190,11 +418,35 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "DeadBush", frequency = .2f });
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "TreeLeafless", frequency = .1f });
-            plantTypes.Add(new PlantInfo() { name = "TreeStump", frequency = .3f });
-            plantTypes.Add(new PlantInfo() { name = "PineTree", frequency = .8f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "DeadBush",
+                frequency = .2f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .3f,
+                bunchChance = .7f,
+                minBunchSize = 2,
+                maxBunchSize = 3,
+                bunchRadius = 2
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeLeafless",
+                frequency = .1f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "TreeStump",
+                frequency = .3f
+            });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "PineTree",
+                frequency = .8f
+            });
             return plantTypes;
         }
     }
@@ -216,7 +468,15 @@ namespace Assets.WorldGen
         private List<PlantInfo> GetPlantInfo()
         {
             List<PlantInfo> plantTypes = new List<PlantInfo>();
-            plantTypes.Add(new PlantInfo() { name = "Rocks", frequency = .4f });
+            plantTypes.Add(new PlantInfo()
+            {
+                name = "Rocks",
+                frequency = .2f,
+                bunchChance = 1,
+                minBunchSize = 2,
+                maxBunchSize = 6,
+                bunchRadius = 2
+            });
             return plantTypes;
         }
     }

--- a/Assets/WorldGen/Biomes.cs
+++ b/Assets/WorldGen/Biomes.cs
@@ -8,6 +8,10 @@ namespace Assets.WorldGen
     {
         public string name;
         public float frequency; // 1 => Everywhere, .7 = Common, .5 = Sparse, .3 = Rare, .1 = Very Rare
+        public float bunchChance;
+        public int minBunchSize;
+        public int maxBunchSize;
+        public float bunchRadius;
     }
 
     public class Biome

--- a/Assets/WorldGen/FloraManager.cs
+++ b/Assets/WorldGen/FloraManager.cs
@@ -118,19 +118,34 @@ namespace Assets.WorldGen
                             continue;
                         }
 
-                        Vector3 pointWithHeight = new Vector3(spawnPoint.x, terrainPointData.height, spawnPoint.z);
-                        Object prefab = GetRandomPrefabOfType(plant.name);
-                        GameObject go = (GameObject)Instantiate(prefab, pointWithHeight, Quaternion.identity, parent);
+                        // Handle bunched flora spawns 
+                        if (plant.bunchChance > 0 && Random.Range(0f, 1f) < plant.bunchChance)
+                        {
+                            int bunchSize = Random.Range(plant.minBunchSize, plant.maxBunchSize + 1);
+                            for (int i = 0; i < bunchSize; i++)
+                            {
+                                Object prefab = GetRandomPrefabOfType(plant.name);
+                                Vector3 position = new Vector3(Random.Range(spawnPoint.x - plant.bunchRadius, spawnPoint.x + plant.bunchRadius),
+                                                                0,
+                                                                Random.Range(spawnPoint.z - plant.bunchRadius, spawnPoint.z + plant.bunchRadius));
+                                position.y = TerrainFunctions.GetTerrainPointData(new Vector2(position.x, position.z)).height;
+                                GameObject go = (GameObject)Instantiate(prefab, position, Quaternion.identity, parent);
+                                go.transform.Rotate(go.transform.up, Random.Range(0, 360)); // Vary direction it's facing
+                                go.transform.up = terrainPointData.normal; // Make normal to ground 
+                                go.transform.localScale = new Vector3(Random.Range(.7f, 1.5f), Random.Range(.7f, 1.5f), Random.Range(.7f, 1.5f)); // Vary size
+                            }
+                        }
 
-                        // Randomly vary direction it's facing and size 
-                        // For some reason, if we do this after rotating according to normal vector, it messes up
-                        go.transform.Rotate(go.transform.up, Random.Range(0, 360));
-
-                        // Make normal to ground 
-                        go.transform.up = terrainPointData.normal;
-
-                        // Randomly scale by a bit just to add variety to the world
-                        go.transform.localScale = new Vector3(Random.Range(.7f, 1.5f), Random.Range(.7f, 1.5f), Random.Range(.7f, 1.5f));
+                        // Otherwise, just spawn a single one 
+                        else
+                        {
+                            Vector3 pointWithHeight = new Vector3(spawnPoint.x, terrainPointData.height, spawnPoint.z);
+                            Object prefab = GetRandomPrefabOfType(plant.name);
+                            GameObject go = (GameObject)Instantiate(prefab, pointWithHeight, Quaternion.identity, parent);
+                            go.transform.Rotate(go.transform.up, Random.Range(0, 360)); // Vary direction it's facing
+                            go.transform.up = terrainPointData.normal; // Make normal to ground 
+                            go.transform.localScale = new Vector3(Random.Range(.7f, 1.5f), Random.Range(.7f, 1.5f), Random.Range(.7f, 1.5f)); // Vary size
+                        }
                     }
                 }
                 yield return null;


### PR DESCRIPTION
Implements the following: 
- **Switches flora generation spawn points to use Poisson disc**
  - Rationale: Limit flora overlaps while eliminating the uniformity of a grid-based distribution
- **Makes it so trees can't spawn on land with a given incline or greater**
  - Rationale: Better realism
- **Prevents most spawns (other than reeds) near or below water level**
  - Rationale: Better realism
- **Flora wasn't correctly being set to perpendicular to the ground; now it is.** Probably a good idea to set this to somewhere between straight up and normal to the ground in the future, as stuff on hills still grows *generally* upwards
  - Rationale: Better realism
- **Implemented flora bunching, which implements options on a biome-specific, plant-specific basis that let you spawn multiple plants at randomized points around the original planned spawn points**
  - Rationale: Better realism, helps world feel less spotty, gives us more knobs through which to affect world gen